### PR TITLE
Fix issue #1: Create new cofig obj in every file read

### DIFF
--- a/MockLocker.Library/AppSettingsManager.cs
+++ b/MockLocker.Library/AppSettingsManager.cs
@@ -9,19 +9,19 @@ namespace MockLocker.Library
 {
     public class AppSettingsManager
     {
-        private readonly IConfigurationRoot Configuration;
-        public AppSettingsManager()
+        private IConfigurationRoot Configuration;
+        public List<string> GetJsonListFromSettings(string key)
         {
             Configuration = new ConfigurationBuilder()
-                                       .SetBasePath(Directory.GetCurrentDirectory())
-                                       .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                                       .Build();
+                                   .SetBasePath(Directory.GetCurrentDirectory())
+                                   .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                                   .Build();
+            return Configuration.GetSection(key).Get<List<string>>();
         }
-
-        public List<string> GetJsonListFromSettings(string key) => Configuration.GetSection(key).Get<List<string>>();
 
         public void UpdateAppSettings(string key, object newValue)
         {
+
             var json = File.ReadAllText("appsettings.json");
             using (JsonDocument document = JsonDocument.Parse(json))
             {


### PR DESCRIPTION
Even though 'reloadOnChange:true' is used in config , it is not really updated every file changes and make the file read method   not updated with the new data.